### PR TITLE
Feature/sipjs 0.15.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3294,9 +3294,9 @@
       "dev": true
     },
     "sip.js": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/sip.js/-/sip.js-0.15.1.tgz",
-      "integrity": "sha512-veTkiyfVGzKJq/HmBrEihZvjx8qPLr/8iXYeKxhzMRIAZDK2OUMxffvh7eXOaYYIJsTVa3mgVG/4gNrjxMbwSQ==",
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/sip.js/-/sip.js-0.15.5.tgz",
+      "integrity": "sha512-qAi+Q4mjQZ6jUYea4ptZqUP7rDRSLe6lgRIWz2uK6PBJdi+t0Kr+U8DO1is46yhDeFiFN7vmP02jFxOR6VsUPA==",
       "requires": {
         "crypto-js": "^3.1.9-1",
         "events": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1157,6 +1157,11 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA=="
+    },
     "evp_bytestokey": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
@@ -3289,11 +3294,20 @@
       "dev": true
     },
     "sip.js": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/sip.js/-/sip.js-0.14.4.tgz",
-      "integrity": "sha512-98630KJpNeLz2VvHNBJPmaq9ZPC9b2VeEMdfF9kLJ+mB2J+TjW4Wfz1ArCDrSBkVuIa28lqISDjk8iConUx6UA==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/sip.js/-/sip.js-0.15.1.tgz",
+      "integrity": "sha512-veTkiyfVGzKJq/HmBrEihZvjx8qPLr/8iXYeKxhzMRIAZDK2OUMxffvh7eXOaYYIJsTVa3mgVG/4gNrjxMbwSQ==",
       "requires": {
-        "crypto-js": "^3.1.9-1"
+        "crypto-js": "^3.1.9-1",
+        "events": "^3.0.0",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+        }
       }
     },
     "slice-ansi": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "p-retry": "^4.1.0",
     "p-timeout": "^3.1.0",
-    "sip.js": "0.15.1"
+    "sip.js": "0.15.5"
   },
   "devDependencies": {
     "eslint": "^5.16.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "p-retry": "^4.1.0",
     "p-timeout": "^3.1.0",
-    "sip.js": "0.14.4"
+    "sip.js": "0.15.1"
   },
   "devDependencies": {
     "eslint": "^5.16.0",

--- a/src/session-description-handler.ts
+++ b/src/session-description-handler.ts
@@ -24,7 +24,7 @@ export function sessionDescriptionHandlerFactory(session, options) {
     remoteStream: new MediaStream()
   };
 
-  (sdh as any).WebRTC.getUserMedia = async () => {
+  (sdh as any).getMediaStream = async () => {
     await session.__media.setInput();
     return session.__streams.localStream.stream;
   };


### PR DESCRIPTION
### Issue number

#5 

### Expected behaviour

WebphoneLib is using SIP.js 0.15.5

### Actual behaviour

WebphoneLib is using SIP.js 0.14.4

### Description of fix

The way to override `getUserMedia` in the `SessionDescriptionHandler` has changed.

### Other info

Verified calling works, but should be tested more extensively.