### PR TITLE
Fix test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,15 @@
     "compileEnhancements": false
   },
   "nyc": {
+    "require": [
+      "ts-node/register"
+    ],
     "extends": "@istanbuljs/nyc-config-typescript",
     "all": true,
-    "check-coverage": true
+    "check-coverage": true,
+    "include": [
+      "src/**/*.ts"
+    ]
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Issue number

#11 

### Expected behaviour

All (touched?) source files are included in the test coverage.

### Actual behaviour

Some files were missing.

### Description of fix

Read through https://github.com/istanbuljs/nyc/issues/618 and found that we were missing a `"require": ["ts-node/register"]` stanza in the `nyc` configuration.

### Other info



