### PR TITLE
Workaround for bug that occured when failed sessions terminate

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -370,6 +370,14 @@ export class ClientImpl extends EventEmitter implements IClient {
   }
 
   private onSessionTerminated(sessionId: string) {
+    if (!(sessionId in this.sessions)) {
+      log.info(
+        `Broken session (probably due to failed invite) ${sessionId} is terminated.`,
+        this.constructor.name
+      );
+      return;
+    }
+
     const session = this.sessions[sessionId];
     log.info(`Session ${sessionId} is terminated.`, this.constructor.name);
     this.removeSession(session);


### PR DESCRIPTION
### Issue number

#14 

### Description of fix

Check if session exists before removing. 

