### PR TITLE
Moved the eventlisteners so that they always exist before play is called.

### DIFF
--- a/src/sound.ts
+++ b/src/sound.ts
@@ -111,21 +111,21 @@ export class Sound {
             this.stopTimer = window.setTimeout(() => this.stop(), timeout);
           }
 
+          sample.addEventListener('pause', () => {
+            cleanup();
+            resolve();
+          });
+
+          sample.addEventListener('ended', () => {
+            cleanup();
+            resolve();
+          });
+
           await sample.play();
         } catch (e) {
           cleanup();
           reject(e);
         }
-      });
-
-      sample.addEventListener('pause', () => {
-        cleanup();
-        resolve();
-      });
-
-      sample.addEventListener('ended', () => {
-        cleanup();
-        resolve();
       });
     });
 


### PR DESCRIPTION
### Issue number

#17 

### Expected behaviour

Sound stops playing when stop() is called.

### Actual behaviour

It does not stop.

### Description of fix

Moved the eventListener up a bit so that it is always initialized before play() is called.

