### PR TITLE
Fixed the findCause error and fixed the 'call completed elsewhere' fo…

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -345,6 +345,8 @@ async function incomingCall(session) {
       await session.accept();
     }
 
+    session.terminated().then(reason => console.log(`Session is terminated, reason: ${reason}`));
+
     const { accepted, rejectCause } = await session.accepted();
 
     acceptCallBtn.hidden = true;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webphone-lib",
-  "version": "0.1.10-beta.4",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -377,11 +377,12 @@ export class ClientImpl extends EventEmitter implements IClient {
       });
     });
 
-    this.transport.on('invite', incomingSession => {
+    this.transport.on('invite', ({ invitation, canceledPromise }) => {
       const session = new Invitation({
         media: this.defaultMedia,
-        session: incomingSession,
+        session: invitation,
         onTerminated: this.onSessionTerminated.bind(this),
+        canceledPromise,
         isIncoming: true
       });
 

--- a/src/invitation.ts
+++ b/src/invitation.ts
@@ -12,6 +12,8 @@ export class Invitation extends SessionImpl {
     this.acceptedPromise = new Promise(resolve => {
       this.acceptedRef = resolve;
     });
+
+    this.canceledPromise = options.canceledPromise;
   }
 
   public accept(): Promise<void> {


### PR DESCRIPTION
…r the new SIP interface

### Issue number

#19 

### Description of fix

The findCause function when a session was rejected was throwing an error. But with the new SIP interface the parsing of a rejectCause is already done for you, so this is now used instead. Furthermore the 'call completed elsewhere' CANCEL cause was not handled in the onReject of the session delegate. This required some patching in the user agent to save the termination cause (i.e. 'Call completed elsewhere' on the session instance so this can be returned in the onTerminated promise.

