### PR TITLE
Changed from a promise to an object

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -377,12 +377,12 @@ export class ClientImpl extends EventEmitter implements IClient {
       });
     });
 
-    this.transport.on('invite', ({ invitation, canceledPromise }) => {
+    this.transport.on('invite', ({ invitation, cancelled }) => {
       const session = new Invitation({
         media: this.defaultMedia,
         session: invitation,
         onTerminated: this.onSessionTerminated.bind(this),
-        canceledPromise,
+        cancelled,
         isIncoming: true
       });
 

--- a/src/invitation.ts
+++ b/src/invitation.ts
@@ -13,7 +13,7 @@ export class Invitation extends SessionImpl {
       this.acceptedRef = resolve;
     });
 
-    this.canceledPromise = options.canceledPromise;
+    this.cancelled = options.cancelled;
   }
 
   public accept(): Promise<void> {

--- a/src/session.ts
+++ b/src/session.ts
@@ -136,6 +136,10 @@ export interface ISessionAccept {
   rejectPhrase?: string;
 }
 
+export interface ISessionCancelled {
+  reason?: string;
+}
+
 /**
  * @hidden
  */
@@ -153,7 +157,7 @@ export class SessionImpl extends EventEmitter implements ISession {
   protected inviteOptions: InviterInviteOptions;
   protected session: Inviter | Invitation;
   protected terminatedReason?: string;
-  protected canceledPromise?: Promise<void>;
+  protected cancelled?: ISessionCancelled;
 
   private acceptedSession: any;
 
@@ -197,14 +201,10 @@ export class SessionImpl extends EventEmitter implements ISession {
           this.status = SessionStatus.TERMINATED;
           this.emit('statusUpdate', { id: this.id, status: this.status });
 
-          // The canceledPromise is currently only used by an Invitation.
+          // The cancelled object is currently only used by an Invitation.
           // For instance when an incoming call is cancelled by the other
           // party or system (i.e. call completed elsewhere).
-          if (this.canceledPromise) {
-            this.canceledPromise.then(resolve);
-          } else {
-            resolve();
-          }
+          resolve(this.cancelled ? this.cancelled.reason : undefined);
         }
       });
     });

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -361,17 +361,16 @@ export class ReconnectableTransport extends EventEmitter implements ITransport {
         // Patch the onCancel delegate function to parse the reason of
         // cancellation. This is then used by the terminatedPromise of
         // a Session to return the reason when a session is terminated.
+        const cancelled = { reason: undefined };
         const onCancel = (invitation as any).incomingInviteRequest.delegate.onCancel;
-        const canceledPromise = new Promise(resolve => {
-          (invitation as any).incomingInviteRequest.delegate.onCancel = (
-            message: Core.IncomingRequestMessage
-          ) => {
-            const reason = this.parseHeader(message.getHeader('reason'));
-            resolve(reason ? CANCELLED_REASON[reason.get('text')] : undefined);
-            onCancel(message);
-          };
-        });
-        this.emit('invite', { invitation, canceledPromise });
+        (invitation as any).incomingInviteRequest.delegate.onCancel = (
+          message: Core.IncomingRequestMessage
+        ) => {
+          const reason = this.parseHeader(message.getHeader('reason'));
+          cancelled.reason = reason ? CANCELLED_REASON[reason.get('text')] : undefined;
+          onCancel(message);
+        };
+        this.emit('invite', { invitation, cancelled });
       }
     };
 


### PR DESCRIPTION
### Issue number

#19 

### Description of fix

Follow up on https://github.com/open-voip-alliance/WebphoneLib/pull/27 that exchanges the cancelledPromise for a cancelled object because it worked for the issue in the ticket but then an accepted call would fail because the cancelledPromise would never resolve.


