### PR TITLE
Session is now added before invite is send

### DIFF
--- a/src/enums.ts
+++ b/src/enums.ts
@@ -8,6 +8,7 @@ export enum ClientStatus {
 }
 
 export enum SessionStatus {
+  TRYING = 'trying',
   RINGING = 'ringing',
   ACTIVE = 'active',
   ON_HOLD = 'on_hold',

--- a/src/invitation.ts
+++ b/src/invitation.ts
@@ -14,6 +14,9 @@ export class Invitation extends SessionImpl {
     });
 
     this.cancelled = options.cancelled;
+
+    this.status = SessionStatus.RINGING;
+    this.emit('statusUpdate', { id: this.id, status: this.status });
   }
 
   public accept(): Promise<void> {

--- a/src/inviter.ts
+++ b/src/inviter.ts
@@ -1,6 +1,7 @@
 import { Core } from 'sip.js';
 import { Inviter as SIPInviter } from 'sip.js/lib/api/inviter';
 
+import { SessionStatus } from './enums';
 import { ISessionAccept, SessionImpl } from './session';
 
 export class Inviter extends SessionImpl {
@@ -39,7 +40,11 @@ export class Inviter extends SessionImpl {
   }
 
   public invite(): Promise<Core.OutgoingInviteRequest> {
-    return this.session.invite(this.inviteOptions);
+    return this.session.invite(this.inviteOptions).then((request: Core.OutgoingInviteRequest) => {
+      this.status = SessionStatus.RINGING;
+      this.emit('statusUpdate', { id: this.id, status: this.status });
+      return request;
+    });
   }
 
   public async accept() {

--- a/src/session.ts
+++ b/src/session.ts
@@ -151,7 +151,7 @@ export class SessionImpl extends EventEmitter implements ISession {
   public readonly isIncoming: boolean;
   public saidBye: boolean;
   public holdState: boolean;
-  public status: SessionStatus = SessionStatus.RINGING;
+  public status: SessionStatus = SessionStatus.TRYING;
 
   protected acceptedPromise: Promise<ISessionAccept>;
   protected inviteOptions: InviterInviteOptions;


### PR DESCRIPTION
### Issue number

#25 

### Expected behaviour

Session is correctly removed on terminate

### Actual behaviour

Session is not always removed when the terminate happens before the reject

### Description of fix

Moved addSession before the actual INVITE is sent to the SIP server

### Other info

Please try to reproduce, we couldn't.

