### PR TITLE
Added updating remote identity on invite

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -327,9 +327,17 @@ async function outgoingCall() {
   console.log('session is terminated', session.id);
 }
 
+function updateCallerHTML(session) {
+  let {
+    remoteIdentity: { displayName },
+    phoneNumber
+  } = session;
+
+  caller.innerHTML = `${displayName} (${phoneNumber})`;
+}
+
 async function incomingCall(session) {
-  const { number, displayName } = session.remoteIdentity;
-  caller.innerHTML = `${displayName} (${number})`;
+  updateCallerHTML(session);
   caller.hidden = false;
 
   acceptCallBtn.hidden = false;
@@ -353,6 +361,13 @@ async function incomingCall(session) {
 
     if (accepted) {
       console.log('session is accepted \\o/', session.id);
+
+      session.on('remoteIdentityUpdate', () => {
+        console.log(
+          `New identity is: ${session.remoteIdentity.displayName} - ${session.phoneNumber}`
+        );
+        updateCallerHTML(session);
+      });
 
       // Terminate the session after 60 seconds
       terminateTimer = setTimeout(() => {

--- a/src/invitation.ts
+++ b/src/invitation.ts
@@ -21,6 +21,13 @@ export class Invitation extends SessionImpl {
       this.status = SessionStatus.ACTIVE;
       this.emit('statusUpdate', { id: this.id, status: this.status });
       this.acceptedRef({ accepted: true });
+
+      this.session.delegate = {
+        onInvite: request => {
+          this._remoteIdentity = this.extractRemoteIdentity();
+          this.emit('remoteIdentityUpdate', this, this.remoteIdentity);
+        }
+      };
     });
   }
 


### PR DESCRIPTION
### Issue number

https://github.com/open-voip-alliance/WebphoneLib/issues/36

### Expected behaviour

The remote identity is updated after completing an attended transfer

### Actual behaviour

The remote identity is not updated after completing an attended transfer, you see the number of the person that transfers you instead.

### Description of fix

Added an onInvite delegator to new incoming sessions, which triggers on reinvites.
