### PR TITLE
Added getters for the localStream and remoteStream of a session

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -45,6 +45,18 @@ export interface ISession {
   remoteIdentity: IRemoteIdentity;
 
   /**
+   * The local stream of this session.
+   * @returns {MediaStream}
+   */
+  localStream: MediaStream;
+
+  /**
+   * The remote stream of this session.
+   * @returns {MediaStream}
+   */
+  remoteStream: MediaStream;
+
+  /**
    * @returns {boolean} if auto answer is on for this session.
    */
   autoAnswer: boolean;
@@ -367,6 +379,14 @@ export class SessionImpl extends EventEmitter implements ISession {
     return this.session.sessionDescriptionHandler.sendDtmf(tones);
   }
 
+  public get localStream() {
+    return (this.session as any).__streams.localStream;
+  }
+
+  public get remoteStream() {
+    return (this.session as any).__streams.remoteStream;
+  }
+
   public freeze(): ISession {
     return createFrozenProxy({}, this, [
       'audioConnected',
@@ -400,7 +420,9 @@ export class SessionImpl extends EventEmitter implements ISession {
       'removeAllListeners',
       'removeListener',
       'cancel',
-      'tried'
+      'tried',
+      'localStream',
+      'remoteStream'
     ]);
   }
 


### PR DESCRIPTION
### Issue number

#47 

### Expected behaviour

You can access the local and remote streams of a session.

### Actual behaviour

You cannot access the local and remote stream of a session.

### Description of fix

Add getters to the SessionImpl class to expose these streams

### Other info

No setters for now until people want it

