### PR TITLE
fix(firefox): try/catch on permission query not supported

### DIFF
--- a/src/media.ts
+++ b/src/media.ts
@@ -75,9 +75,13 @@ class MediaSingleton extends EventEmitter implements IMediaDevices {
       return this.requestPermissionPromise;
     }
 
-    const { state } = await navigator.permissions.query({ name: 'microphone' });
-    if (state === 'granted') {
-      return;
+    try {
+      const { state } = await navigator.permissions.query({ name: 'microphone' });
+      if (state === 'granted') {
+        return;
+      }
+    } catch (err) {
+      console.error('permissions query mic not supported in firefox, doing fallback', err);
     }
 
     // eslint-disable-next-line no-async-promise-executor


### PR DESCRIPTION
### Expected behaviour

- Prompt and get audio input devices in Firefox

### Actual behaviour

- Threw TypeError and not getting user media devices in Firefox

### Other info

related to: https://github.com/open-voip-alliance/WebphoneLib/issues/43

I opened an issue about this and someone implemented but for what I see, it has not tested in firefox, thanks.