### PR TITLE
Removed redunant navigator.permissions.query

### DIFF
--- a/src/media.ts
+++ b/src/media.ts
@@ -85,12 +85,6 @@ class MediaSingleton extends EventEmitter implements IMediaDevices {
     }
 
     // eslint-disable-next-line no-async-promise-executor
-    const { state } = await navigator.permissions.query({ name: 'microphone' });
-    if (state === 'granted') {
-      return;
-    }
-
-    // eslint-disable-next-line no-async-promise-executor
     this.requestPermissionPromise = new Promise(async (resolve, reject) => {
       try {
         const stream = await navigator.mediaDevices.getUserMedia({


### PR DESCRIPTION
### Issue number

#62 

### Expected behaviour

The microphone permissions is handled in a cross-browser compatible way when navigator.permissions.query is not supported.

### Actual behaviour

In Firefox navigator.permission.query is not supported, leading to an error, see stacktrace.

### Description of fix

Removed the redundant `navigator.permissions.query` that was causing an error in Firefox because it is not supported yet.

