### PR TITLE
remembering CSeq of messages to prevent faulty subcription updates

### DIFF
--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -43,3 +43,13 @@ export function statusFromDialog(notification: any): SubscriptionStatus | string
 
   return state;
 }
+
+/**
+ * Parse an incoming notification request header and return
+ * the CSeq number from it.
+ * @param {any} notification - A SIP.js Request object.
+ * @returns {Number} - The CSeq number of a notification.
+ */
+export function cseqFromDialog(notification: any): number {
+  return notification.request.headers.CSeq[0].parsed.value;
+}


### PR DESCRIPTION

### Expected behaviour

Correct BLF statuses for users.

### Actual behaviour

Right now some Notify (UDP) packets with a lower CSeq number will arrive after a Notify with a higher number.
In sip.js this will throw a Internal server error. 
```javascript
if (this.remoteSequenceNumber && message.cseq <= this.remoteSequenceNumber) {
      this.core.replyStateless(message, { statusCode: 500 });
      return false;
}
```
This means that the BLF status for users doesn't update correctly. For example some users kept being on ringing or in a call were they were already out of a call.

### Description of fix

We will not emit a notify subscription update of Notifications with a lower CSeq number than the CSeq number we currently have for that URI. 

