### PR TITLE
Added a patched userAgentCore.onInvite with onBeforeInvite

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,6 @@
   "rules": {
     "curly": ["error", "all"],
     "brace-style": ["error", "1tbs"],
-    "indent": ["warn", 2],
     "no-console": "off",
     "prettier/prettier": "error"
   }

--- a/demo/lib/calling.mjs
+++ b/demo/lib/calling.mjs
@@ -22,10 +22,25 @@ let transport;
 
 export let client;
 
+function onBeforeInvite(invitation) {
+  if (localStorage.getItem('dndEnabled') === 'true') {
+    // Send the 486 'Busy here' status instead of the default 480 'Unavailable'.
+    invitation.reject({ statusCode: 486 });
+    // Prevents onInvite to progress any further.
+    return true;
+  }
+
+  // Nothing to see here, move along.
+  return false;
+}
+
 export function setTransport(websocketUrl) {
   transport = {
     wsServers: websocketUrl,
-    iceServers: []
+    iceServers: [],
+    delegate: {
+      onBeforeInvite
+    }
   };
 }
 
@@ -69,13 +84,8 @@ function onSessionsUpdated() {
   callingEvents.dispatchEvent(new CustomEvent('sessionsUpdated'));
 }
 
-function onInvite(session) {
-  if (localStorage.getItem('dndEnabled') === 'true') {
-    // Send the 486 'Busy here' status instead of the default 480 'Unavailable'.
-    session.reject({ statusCode: 486 });
-  } else {
-    callingEvents.dispatchEvent(new CustomEvent('sessionsUpdated'));
-  }
+function onInvite() {
+  callingEvents.dispatchEvent(new CustomEvent('sessionsUpdated'));
 }
 
 export const subscriptionEvents = eventTarget();

--- a/src/client.ts
+++ b/src/client.ts
@@ -358,6 +358,8 @@ export class ClientImpl extends EventEmitter implements IClient {
   private configureTransport(uaFactory: UAFactory, options: IClientOptions) {
     this.transport = this.transportFactory(uaFactory, options);
 
+    this.transport.delegate = options.transport.delegate;
+
     this.transport.on('reviveSessions', () => {
       Object.values(this.sessions).forEach(async session => {
         session.rebuildSessionDescriptionHandler();
@@ -515,20 +517,20 @@ export const Client: ClientCtor = (function(clientOptions: IClientOptions) {
   createFrozenProxy(this, impl, [
     'attendedTransfer',
     'connect',
+    'createPublisher',
+    'defaultMedia',
     'disconnect',
     'getSession',
     'getSessions',
     'invite',
-    'createPublisher',
     'isConnected',
     'on',
     'once',
     'reconfigure',
     'removeAllListeners',
     'removeListener',
-    'subscribe',
     'resubscribe',
-    'unsubscribe',
-    'defaultMedia'
+    'subscribe',
+    'unsubscribe'
   ]);
 } as any) as ClientCtor;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { ITransportDelegate } from './transport';
+
 export interface IClientOptions {
   account: {
     user: string;
@@ -8,6 +10,7 @@ export interface IClientOptions {
   transport: {
     wsServers: string;
     iceServers: string[];
+    delegate: ITransportDelegate;
   };
   media: IMedia;
   userAgentString?: string;


### PR DESCRIPTION
Alternative, more generic, solution to https://github.com/open-voip-alliance/WebphoneLib/pull/76

### Issue number

#75

### Description of fix

Added an additional onBeforeInvite delegate to the userAgentCore.delegate.onInvite that allows someone to do something with an invitation (or check something) and stop the onInvite early if they need to.

