### PR TITLE
undoing work with CSEQ

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -16,7 +16,7 @@ import { Inviter } from './inviter';
 import { createFrozenProxy } from './lib/freeze';
 import { log } from './logger';
 import { ISession, SessionImpl } from './session';
-import { statusFromDialog, cseqFromDialog } from './subscription';
+import { statusFromDialog } from './subscription';
 import { second } from './time';
 import { ITransport, ReconnectableTransport, TransportFactory, UAFactory } from './transport';
 import { IClientOptions, IMedia } from './types';
@@ -149,7 +149,6 @@ export class ClientImpl extends EventEmitter implements IClient {
 
   private readonly sessions: { [index: string]: SessionImpl } = {};
   private subscriptions: { [index: string]: Subscriber } = {};
-  private subscriptionSequenceNumbers: { [index: string]: number } = {};
   private connected = false;
 
   private transportFactory: TransportFactory;
@@ -252,14 +251,7 @@ export class ClientImpl extends EventEmitter implements IClient {
       this.subscriptions[uri].delegate = {
         onNotify: (notification: Notification) => {
           notification.accept();
-          // oldSequenceNumber will be defaulted to -1 if it is not set yet.
-          const oldSequenceNumber = this.subscriptionSequenceNumbers[uri] || -1;
-          const currentSequenceNumber = cseqFromDialog(notification);
-
-          if (currentSequenceNumber > oldSequenceNumber) {
-            this.subscriptionSequenceNumbers[uri] = currentSequenceNumber;
-            this.emit('subscriptionNotify', uri, statusFromDialog(notification));
-          }
+          this.emit('subscriptionNotify', uri, statusFromDialog(notification));
         }
       };
 
@@ -467,7 +459,6 @@ export class ClientImpl extends EventEmitter implements IClient {
       this.subscriptions[uri].dispose();
     }
 
-    delete this.subscriptionSequenceNumbers[uri];
     delete this.subscriptions[uri];
   }
 

--- a/src/subscription.ts
+++ b/src/subscription.ts
@@ -43,13 +43,3 @@ export function statusFromDialog(notification: any): SubscriptionStatus | string
 
   return state;
 }
-
-/**
- * Parse an incoming notification request header and return
- * the CSeq number from it.
- * @param {any} notification - A SIP.js Request object.
- * @returns {Number} - The CSeq number of a notification.
- */
-export function cseqFromDialog(notification: any): number {
-  return notification.request.headers.CSeq[0].parsed.value;
-}


### PR DESCRIPTION
### Expected behaviour
We expected this would help with BLF statuses. I did not.

### Actual behaviour

Actually nothing. SIP js throws an 500 internal server error when a CSEQ number is lower than the remembered CSEQ number. The onNotify is never called.

### Description of fix

Deleting the "fix".

