### PR TITLE
Added try catch for input audio node disconnect to catch if it is already disconnected

### DIFF
--- a/src/session-media.ts
+++ b/src/session-media.ts
@@ -237,7 +237,10 @@ export class SessionMedia extends EventEmitter implements ISessionMedia {
         this.inputNode.disconnect();
       } catch (e) {
         if (e && e.name === 'InvalidAccessError') {
-          log.debug('cannot disconnect input audio node as the input is already muted', 'media');
+          log.debug(
+            'cannot disconnect input audio node as the input audio node is already disconnected',
+            'media'
+          );
         } else {
           throw e;
         }

--- a/src/session-media.ts
+++ b/src/session-media.ts
@@ -71,53 +71,51 @@ export class SessionMedia extends EventEmitter implements ISessionMedia {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
 
-    // prettier-ignore
     this.input = {
       get id() {
-        return self.media.input.id; 
+        return self.media.input.id;
       },
       set id(value) {
-        self.setInputDevice(value); 
+        self.setInputDevice(value);
       },
       get audioProcessing() {
-        return self.media.input.audioProcessing; 
+        return self.media.input.audioProcessing;
       },
       set audioProcessing(value) {
-        self.setInputAudioProcessing(value); 
+        self.setInputAudioProcessing(value);
       },
       get volume() {
-        return self.media.input.volume; 
+        return self.media.input.volume;
       },
       set volume(value) {
-        self.setInputVolume(value); 
+        self.setInputVolume(value);
       },
       get muted() {
-        return self.media.input.muted; 
+        return self.media.input.muted;
       },
       set muted(value) {
-        self.setInputMuted(value); 
+        self.setInputMuted(value);
       }
     };
 
-    // prettier-ignore
     this.output = {
       get id() {
-        return self.media.output.id; 
+        return self.media.output.id;
       },
       set id(value) {
-        self.setOutputDevice(value); 
+        self.setOutputDevice(value);
       },
       get volume() {
-        return self.media.output.volume; 
+        return self.media.output.volume;
       },
       set volume(value) {
-        self.setOutputVolume(value); 
+        self.setOutputVolume(value);
       },
       get muted() {
-        return self.media.output.muted; 
+        return self.media.output.muted;
       },
       set muted(value) {
-        self.setOutputMuted(value); 
+        self.setOutputMuted(value);
       }
     };
   }
@@ -196,7 +194,11 @@ export class SessionMedia extends EventEmitter implements ISessionMedia {
   private setInputMuted(newMuted: boolean) {
     if (this.inputNode) {
       if (newMuted) {
-        this.inputNode.disconnect((this.session as any).__streams.localStream);
+        try {
+          this.inputNode.disconnect((this.session as any).__streams.localStream);
+        } catch {
+          log.debug('cannot disconnect input audio node as the input is already muted', 'media');
+        }
       } else {
         this.inputNode.connect((this.session as any).__streams.localStream);
       }
@@ -227,7 +229,14 @@ export class SessionMedia extends EventEmitter implements ISessionMedia {
   private stopInput() {
     if (this.inputStream) {
       Media.closeStream(this.inputStream);
-      this.inputNode.disconnect();
+      try {
+        this.inputNode.disconnect();
+      } catch {
+        log.debug(
+          'cannot disconnect input audio node as the audio node is already disconnected',
+          'media'
+        );
+      }
     }
   }
 

--- a/src/session-media.ts
+++ b/src/session-media.ts
@@ -196,8 +196,12 @@ export class SessionMedia extends EventEmitter implements ISessionMedia {
       if (newMuted) {
         try {
           this.inputNode.disconnect((this.session as any).__streams.localStream);
-        } catch {
-          log.debug('cannot disconnect input audio node as the input is already muted', 'media');
+        } catch (e) {
+          if (e && e.name === 'InvalidAccessError') {
+            log.debug('cannot disconnect input audio node as the input is already muted', 'media');
+          } else {
+            throw e;
+          }
         }
       } else {
         this.inputNode.connect((this.session as any).__streams.localStream);
@@ -231,11 +235,12 @@ export class SessionMedia extends EventEmitter implements ISessionMedia {
       Media.closeStream(this.inputStream);
       try {
         this.inputNode.disconnect();
-      } catch {
-        log.debug(
-          'cannot disconnect input audio node as the audio node is already disconnected',
-          'media'
-        );
+      } catch (e) {
+        if (e && e.name === 'InvalidAccessError') {
+          log.debug('cannot disconnect input audio node as the input is already muted', 'media');
+        } else {
+          throw e;
+        }
       }
     }
   }


### PR DESCRIPTION
Added try catch for input audio node disconnect to catch if it is already disconnected

### Issue number

{if exists provide related issue}

### Expected behaviour

In the demo when you spam click hold (which always wants to hold the session, it's not a toggle) you'll get the error that the audio node can't be disconnected because it is not connected in the first place

### Actual behaviour

Error is caught and a debug log is added

