### PR TITLE
Handle 'it broke woops' error

### DIFF
--- a/src/transport.ts
+++ b/src/transport.ts
@@ -371,10 +371,9 @@ export class ReconnectableTransport extends EventEmitter implements ITransport {
           // caught by pRetry.
           if (mode === ReconnectionMode.BURST) {
             reject('reject to trigger pRetry that tries to reconnect to sip server');
-            return;
+          } else {
+            resolve(false);
           }
-
-          resolve(false);
         },
         onOpen: () => {
           log.debug('Opening a socket to sip server worked.', this.constructor.name);

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -370,7 +370,7 @@ export class ReconnectableTransport extends EventEmitter implements ITransport {
           // In the case that mode is BURST, reject the promise which can be
           // caught by pRetry.
           if (mode === ReconnectionMode.BURST) {
-            reject('reject to trigger pRetry that tries to reconnect to sip server');
+            reject('Connection to sip server broke, try to reconnect');
           } else {
             resolve(false);
           }

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -356,7 +356,7 @@ export class ReconnectableTransport extends EventEmitter implements ITransport {
     this.emit('statusUpdate', status);
   }
 
-  private isOnlinePromise(mode: ReconnectionMode) {
+  private isOnlinePromise() {
     return new Promise(resolve => {
       const checkSocket = new WebSocket(this.uaOptions.transportOptions.wsServers, 'sip');
 
@@ -364,12 +364,6 @@ export class ReconnectableTransport extends EventEmitter implements ITransport {
         onError: e => {
           log.debug(e, this.constructor.name);
           checkSocket.removeEventListener('open', handlers.onOpen);
-          // In the case that mode is BURST, throw an error which can be
-          // catched by pRetry.
-          if (mode === ReconnectionMode.BURST) {
-            throw new Error('it broke woops');
-          }
-
           resolve(false);
         },
         onOpen: () => {
@@ -548,7 +542,7 @@ export class ReconnectableTransport extends EventEmitter implements ITransport {
     }
 
     const tryOpeningSocketWithTimeout = () =>
-      pTimeout(this.isOnlinePromise(mode), 5000, () => {
+      pTimeout(this.isOnlinePromise(), 5000, () => {
         // In the case that mode is BURST, throw an error which can be
         // catched by pRetry.
         if (mode === ReconnectionMode.BURST) {

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -363,7 +363,10 @@ export class ReconnectableTransport extends EventEmitter implements ITransport {
       const handlers = {
         onError: e => {
           log.debug(e, this.constructor.name);
+
           checkSocket.removeEventListener('open', handlers.onOpen);
+          checkSocket.removeEventListener('error', handlers.onError);
+
           // In the case that mode is BURST, reject the promise which can be
           // caught by pRetry.
           if (mode === ReconnectionMode.BURST) {
@@ -376,6 +379,7 @@ export class ReconnectableTransport extends EventEmitter implements ITransport {
         onOpen: () => {
           log.debug('Opening a socket to sip server worked.', this.constructor.name);
           checkSocket.close();
+          checkSocket.removeEventListener('open', handlers.onOpen);
           checkSocket.removeEventListener('error', handlers.onError);
           resolve(true);
         }


### PR DESCRIPTION
### Expected behaviour

'it broke woops' error should be caught and not be unhandled in production code

### Actual behaviour

the 'it broke woops' error leaks into production code because the thrown error is not correctly caught

### Description of fix

changed from an `throw` to rejecting the promise the handler is in
